### PR TITLE
Add GSA-Net (2020 arXiv paper by Google Research)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Collect some Transformer with Computer-Vision (CV) papers. If you find some igno
   - A Survey on Visual Transformer [[paper](https://arxiv.org/abs/2012.12556)]   - 2020.12.24
 
 ### arXiv papers
+- **[GSA-Net]** Global Self-Attention Networks for Image Recognition[[paper](https://arxiv.org/abs/2010.03019)]
 - High-Fidelity Pluralistic Image Completion with Transformers[[paper](https://arxiv.org/abs/2103.14031)] [[code](http://raywzy.com/ICT)]
 - Swin Transformer: Hierarchical Vision Transformer using Shifted Windows[[paper](https://arxiv.org/abs/2103.14030)] [[code](https://github.com/microsoft/Swin-Transformer)]
 - **[DPT]** Vision Transformers for Dense Prediction[[paper](https://arxiv.org/abs/2103.13413)] [[code](https://github.com/intel-isl/DPT)]


### PR DESCRIPTION
GSA-Net is a 2020 arXiv paper by Google Research. It proposed a fully-attentional backbone network for computer vision, GSA-Net, and demonstrated significantly better performance on ImageNet vs. ResNet baselines. Specifically, GSA-Net-50 improves the top-1 accuracy by 1.6% vs. ResNet-50, while using 50% the parameters and 70% the computation (FLOPs).