### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Multimodal Multitask Learning with a Unified Transformer [[paper](https://arxiv.
 - **[OSTrack]** Joint Feature Learning and Relation Modeling for Tracking: A One-Stream Framework [[paper](https://arxiv.org/abs/2203.11991)] [[code](https://github.com/botaoye/OSTrack)]
 - **[Unicorn]** Towards Grand Unification of Object Tracking [[paper](https://arxiv.org/abs/2207.07078)] [[code](https://github.com/MasterBin-IIAU/Unicorn)]
 - **[P3AFormer]** Tracking Objects as Pixel-wise Distributions [[paper](https://arxiv.org/abs/2207.05518)] [[code](https://github.com/dvlab-research/ECCV22-P3AFormer-Tracking-Objects-as-Pixel-wise-Distributions)]
+- **[TS2-Net]** TS2-Net: Token Shift and Selection Transformer for Text-Video Retrieval [[paper](https://arxiv.org/abs/2207.07852)] [[code](https://github.com/LiuRicky/ts2_net)]
 
 **CVPR**
 - **[MAE]** Masked Autoencoders Are Scalable Vision Learners [[paper](https://arxiv.org/abs/2111.06377)] [[code]](https://github.com/facebookresearch/mae)


### PR DESCRIPTION
Updated ECCV 2022's TS2-Net: Token Shift and Selection Transformer for Text-Video Retrieval Paper.