### PR TITLE
adding Superpoint Transformer (ICCV'23 with 3DV'24 Oral follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If you find some overlooked papers, please open issues or pull requests (recomme
   - A Survey of Transformers  [[paper](https://arxiv.org/abs/2106.04554)]   - 2020.6.09
 
 ### arXiv papers
+- **[Superpoint Transformer]** Efficient 3D Semantic Segmentation with Superpoint Transformer [[paper](https://arxiv.org/abs/2306.08045)] [[code](https://github.com/drprojects/superpoint_transformer)]
 - Understanding Gaussian Attention Bias of Vision Transformers Using Effective Receptive [[paper](https://arxiv.org/abs/2305.04722)]
 - **[FocusedDecoder]** Focused Decoding Enables 3D Anatomical Detection by Transformers [[paper](https://arxiv.org/abs/2207.10774v4)] [[code](https://github.com/bwittmann/transoar)]
 - **[TAG]** TAG: Boosting Text-VQA via Text-aware Visual Question-answer Generation [[paper](https://arxiv.org/abs/2208.01813)] [[code](https://github.com/HenryJunW/TAG)]


### PR DESCRIPTION
Hello, 

Thanks for maintaining this awesome repo ! I would like to suggest a new method for the "arxiv" section.

Superpoint Transformer (ICCV'23 with 3D'24 Oral follow-up) is an active project for efficient 3D deep learning. The project implements two papers for semantic and panoptic segmentation, repsectively. This project is from the same authors as the highly-cited [superpoint_graph](https://github.com/loicland/superpoint_graph) (already in the list) and improves it in all regards: faster, better performance, better codebase, more datasets, more pretrained models, new panoptic task...

Besides, this active project involves both academic and industrial users. It counts several undergoing extension projects that will likely offer more features in the near future: better cross-platform support, improved 3D pipeline, additional modalities.

Thanks for considering this PR :pray: 